### PR TITLE
Restrict report confirms to members of Hotline

### DIFF
--- a/src/plugin/report-plugin/Listener/ReportListener.ts
+++ b/src/plugin/report-plugin/Listener/ReportListener.ts
@@ -155,7 +155,7 @@ export default class ReportListener {
             }
 
             // Only allow members who are in the Member role.
-            if (member.roles.indexOf('531617261077790720') == -1) {
+            if (!member.roles.includes('531617261077790720')) {
                 return;
             }
         } catch (e) {

--- a/src/plugin/report-plugin/Listener/ReportListener.ts
+++ b/src/plugin/report-plugin/Listener/ReportListener.ts
@@ -145,6 +145,23 @@ export default class ReportListener {
             return;
         }
 
+        // Only allow Hotline members to react
+        const hotline = this.client.guilds.get('204100839806205953');
+            
+        try {
+            const member = hotline.members.get(userId);
+            if (!member) {
+                return;
+            }
+
+            // Only allow members who are in the Member role.
+            if (member.roles.indexOf('531617261077790720') == -1) {
+                return;
+            }
+        } catch (e) {
+            return;
+        }
+
         const reportMessage = await this.reportMessageRepo.findOne({messageId: message.id});
         if (!reportMessage) {
             return;

--- a/src/plugin/report-plugin/Listener/ReportListener.ts
+++ b/src/plugin/report-plugin/Listener/ReportListener.ts
@@ -147,18 +147,19 @@ export default class ReportListener {
 
         // Only allow Hotline members to react
         const hotline = this.client.guilds.get('204100839806205953');
-            
-        try {
-            const member = hotline.members.get(userId);
-            if (!member) {
-                return;
-            }
 
-            // Only allow members who are in the Member role.
-            if (!member.roles.includes('531617261077790720')) {
-                return;
-            }
-        } catch (e) {
+        if (!hotline) {
+            return;
+        }
+
+        const member = hotline.members.get(userId);
+
+        if (!member) {
+            return;
+        }
+
+        // Only allow members who are in the Member role.
+        if (!member.roles.includes('531617261077790720')) {
             return;
         }
 


### PR DESCRIPTION
This check is based on the command handler beforeExecute check.

This hasn't been tested locally, but it should work.